### PR TITLE
Teach Bogofilter spam mails that were detected by Rspamd only

### DIFF
--- a/.mailfilters/handlespam
+++ b/.mailfilters/handlespam
@@ -109,7 +109,7 @@ if ( ! $REDELIVER_HAM )
 
     log "$SPAM_SERVICE - Spam detected:"
 
-    if ( /^X-Bogosity: (Spam|Yes), tests=bogofilter/ )
+    if ( /^X-Bogosity: (Spam|Yes), tests=bogofilter/ || $SILENT_NEW_SPAM )
     {
       # Adding 'X-Spam-Folder: YES' Header
       xfilter "reformail -a'X-Spam-Folder: YES'"

--- a/.mailfilters/handlespam
+++ b/.mailfilters/handlespam
@@ -109,8 +109,11 @@ if ( ! $REDELIVER_HAM )
 
     log "$SPAM_SERVICE - Spam detected:"
 
-    # Adding 'X-Spam-Folder: YES' Header
-    xfilter "reformail -a'X-Spam-Folder: YES'"
+    if ( /^X-Bogosity: (Spam|Yes), tests=bogofilter/ )
+    {
+      # Adding 'X-Spam-Folder: YES' Header
+      xfilter "reformail -a'X-Spam-Folder: YES'"
+    }
 
     DESTDIR="$MAILDIR/$JUNKDIR"
     SILENT_DESTDIR=$SILENT_NEW_SPAM

--- a/spam-learn
+++ b/spam-learn
@@ -119,7 +119,8 @@ do
         do
             find "${DIR}/${JUNKDIR}/${SUBDIR}" -mmin -$((60*24)) -type f -print0 | while read -d $'\0' -r spammail ;
             do
-              if ! grep -q "X-Spam-Folder: YES" $spammail;
+              MAIL_SEEN=":2,[a-zPRTDFI]*S[a-zPRTDFI]*$"
+              if ! grep -q "X-Spam-Folder: YES" $spammail && [[ $spammail =~ $MAIL_SEEN ]];
               then
                 [ "${VERBOSE}" == "1" ] && echo -e "\tEating spam \"${spammail}\". Yuk!"
                 if [ "${DRYRUN}" == "0" ];


### PR DESCRIPTION
Mails that are classified by Rspamd as spam but not by Bogofilter are treated as spam. This small change teaches Bogofilter that such mails are spam to improve Bogofilter's accuracy.

The logic changes as follows: If mails are classified as spam by Rspamd only, they do not get the "X-Spam-Folder: YES" header. After they have been read and left in the spam folder, they are learned by Bogofilter as spam. If mails are not marked as read or moved to another folder directly after reading, nothing happens.
Thus, to teach Bogofilter, one has to mark correctly classified spam mails as read.